### PR TITLE
Downgrade AGP to the latest stable version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0-alpha01' apply false
-    id 'com.android.library' version '7.4.0-alpha01' apply false
+    id 'com.android.application' version '7.2.1' apply false
+    id 'com.android.library' version '7.2.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }


### PR DESCRIPTION
This PR downgrade the Android Gradle Plugin from version `7.4.0-alpha01` to `7.2.1` (the latest stable as of this PR).

**Why?:**
While using the canary version is nice for trying features, it can also cause issues.
Because the `7.4.0-alpha01` is already outdated, I had to upgrade to `7.4.0-alpha02`. Unfortunately, even with the latest alpha version, I couldn't build the project.
Using the latest stable version ensures contributors don't have to update the AGP version as often as it would be required with the alpha version of the plugin.